### PR TITLE
Allow some customization in Launcher3

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -20,7 +20,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.android.launcher3">
-    <uses-sdk android:targetSdkVersion="21" android:minSdkVersion="16"/>
+    <uses-sdk android:targetSdkVersion="21" android:minSdkVersion="21"/>
 
     <permission
         android:name="com.android.launcher.permission.INSTALL_SHORTCUT"
@@ -152,6 +152,12 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name="com.android.launcher3.LauncherPreferencesActivity"
+            android:theme="@style/LauncherTheme"
+            android:excludeFromRecents="true">
         </activity>
 
         <!-- Debugging tools -->

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -135,4 +135,9 @@
     <declare-styleable name="InsettableFrameLayout_Layout">
         <attr name="layout_ignoreInsets" format="boolean" />
     </declare-styleable>
+
+    <declare-styleable name="NumberPreference">
+        <attr name="min" format="integer"></attr>
+        <attr name="max" format="integer"></attr>
+    </declare-styleable>
 </resources>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -36,4 +36,10 @@
     <color name="outline_color">#FFFFFFFF</color>
     <color name="widget_text_panel">#FF374248</color>
 
+    <!-- Launcher Settings -->
+    <color name="primary">#ff303F9F</color>
+    <color name="primary_dark">#ff283593</color>
+    <color name="primary_light">#ff3949AB</color>
+    <color name="accent">#ff303F9F</color>
+
 </resources>

--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Folder titles -->
+    <string name="google_title" translatable="false">Google</string>
+
+    <!-- Preferences -->
+    <string name="pref_workspace_title">Workspace settings</string>
+    <string name="pref_title_workspace_rows">Rows</string>
+    <string name="pref_title_workspace_cols">Columns</string>
+    <string name="pref_title_default_workspace">Default Screen</string>
+    <string name="pref_title_show_search_bar">Show Search Bar</string>
+
+</resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -95,4 +95,15 @@
         <item name="android:paddingLeft">@dimen/app_widget_preview_padding_left</item>
     </style>
 
+    <style name="SearchButton.WithPaddingStart">
+        <item name="android:paddingLeft">8dp</item>
+    </style>
+
+    <!-- Launcher Settings -->
+    <style name="LauncherTheme" parent="@android:style/Theme.Material.Light.DarkActionBar">
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:colorPrimary">@color/primary</item>
+        <item name="android:colorPrimaryDark">@color/primary_dark</item>
+        <item name="android:colorAccent">@color/accent</item>
+    </style>
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:launcher="http://schemas.android.com/apk/res-auto/com.android.launcher3">
+    <PreferenceCategory
+        android:title="@string/pref_workspace_title"
+        android:key="pref_key_workspace_settings">
+
+        <com.android.launcher3.NumberPreference
+            android:key="pref_key_workspaceRows"
+            android:title="@string/pref_title_workspace_rows"
+            launcher:min="1"
+            launcher:max="10" />
+
+        <com.android.launcher3.NumberPreference
+            android:key="pref_key_workspaceCols"
+            android:title="@string/pref_title_workspace_cols"
+            launcher:min="1"
+            launcher:max="10" />
+
+        <com.android.launcher3.NumberPreference
+            android:key="pref_key_workspaceDefaultPage"
+            android:title="@string/pref_title_default_workspace"
+            android:defaultValue="0"
+            launcher:min="0"
+            launcher:max="10" />
+
+        <SwitchPreference
+            android:key="pref_key_showSearchBar"
+            android:title="@string/pref_title_show_search_bar"
+            android:defaultValue="true" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -19,6 +19,7 @@ package com.android.launcher3;
 import android.appwidget.AppWidgetHostView;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Paint;
@@ -122,7 +123,9 @@ public class DeviceProfile {
     int allAppsNumRows;
     int allAppsNumCols;
     int searchBarSpaceWidthPx;
+    int searchBarSpaceMaxWidthPx;
     int searchBarSpaceHeightPx;
+    int searchBarHeightPx;
     int pageIndicatorHeightPx;
     int allAppsButtonVisualSize;
 
@@ -370,10 +373,10 @@ public class DeviceProfile {
         hotseatIconSizePx = (int) (DynamicGrid.pxFromDp(hotseatIconSize, dm) * scale);
 
         // Search Bar
-        searchBarSpaceWidthPx = Math.min(widthPx,
-                resources.getDimensionPixelSize(R.dimen.dynamic_grid_search_bar_max_width));
-        searchBarSpaceHeightPx = getSearchBarTopOffset()
-                + resources.getDimensionPixelSize(R.dimen.dynamic_grid_search_bar_height);
+        searchBarSpaceMaxWidthPx = resources.getDimensionPixelSize(R.dimen.dynamic_grid_search_bar_max_width);
+        searchBarHeightPx = resources.getDimensionPixelSize(R.dimen.dynamic_grid_search_bar_height);
+        searchBarSpaceWidthPx = Math.min(searchBarSpaceMaxWidthPx, widthPx);
+        searchBarSpaceHeightPx = searchBarHeightPx + getSearchBarTopOffset();
 
         // Calculate the actual text height
         Paint textPaint = new Paint();
@@ -437,6 +440,26 @@ public class DeviceProfile {
         availableHeightPx = ahPx;
 
         updateAvailableDimensions(context);
+    }
+
+    void updateFromPreferences(SharedPreferences prefs) {
+        int prefNumColumns = prefs.getInt(LauncherPreferences.KEY_WORKSPACE_COLS, 0);
+        if(prefNumColumns > 0) {
+            numColumns = prefNumColumns;
+        }
+
+        int prefNumRows = prefs.getInt(LauncherPreferences.KEY_WORKSPACE_ROWS, 0);
+        if(prefNumRows > 0) {
+            numRows = prefNumRows;
+        }
+
+        boolean showSearchBar = prefs.getBoolean(LauncherPreferences.KEY_SHOW_SEARCHBAR, true);
+        if(showSearchBar) {
+            searchBarSpaceHeightPx = searchBarHeightPx + 2 * edgeMarginPx;
+        }
+        else {
+            searchBarSpaceHeightPx = 2 * edgeMarginPx;
+        }
     }
 
     private float dist(PointF p0, PointF p1) {

--- a/src/com/android/launcher3/LauncherPreferences.java
+++ b/src/com/android/launcher3/LauncherPreferences.java
@@ -1,0 +1,61 @@
+package com.android.launcher3;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+import android.util.Log;
+
+public final class LauncherPreferences {
+        public static final String KEY_WORKSPACE_ROWS = "pref_key_workspaceRows";
+        public static final String KEY_WORKSPACE_COLS = "pref_key_workspaceCols";
+
+        public static final String KEY_WORKSPACE_DEFAULT_PAGE = "pref_key_workspaceDefaultPage";
+
+        public static final String KEY_SHOW_SEARCHBAR = "pref_key_showSearchBar";
+
+        private static final String TAG = "LauncherPreferences";
+
+        public static class PrefsFragment  extends PreferenceFragment {
+            @Override
+            public void onCreate(Bundle savedInstanceState) {
+                super.onCreate(savedInstanceState);
+
+                // Load the preferences from an XML resource
+                addPreferencesFromResource(R.xml.preferences );
+
+                SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
+
+                DynamicGrid grid = LauncherAppState.getInstance().getDynamicGrid();
+
+                if(grid != null) {
+                        // initialize default values from current Profile
+                        DeviceProfile prof = grid.getDeviceProfile();
+
+                        SharedPreferences.Editor editor = prefs.edit();
+
+                        if(prefs.getInt(KEY_WORKSPACE_ROWS, 0) < 1) {
+                                Log.i(TAG,"Loading r default value from: "+grid.toString());
+                                editor.putInt(KEY_WORKSPACE_ROWS, (int)prof.numRows);
+                        }
+                        if(prefs.getInt(KEY_WORKSPACE_COLS, 0) < 1) {
+                                Log.i(TAG,"Loading c default value from: "+grid.toString());
+                                editor.putInt(KEY_WORKSPACE_COLS, (int)prof.numColumns);
+                        }
+
+                        editor.apply();
+                }
+                else {
+                        Log.w(TAG, "No DynamicGrid to get default values!");
+            }
+            }
+        }
+
+        private LauncherPreferences() {}
+
+        public static boolean isLauncherPreference(String key) {
+                return key.equals(KEY_WORKSPACE_ROWS)
+                                || key.equals(KEY_WORKSPACE_COLS)
+                                || key.equals(KEY_WORKSPACE_DEFAULT_PAGE)
+                                || key.equals(KEY_SHOW_SEARCHBAR);
+        }
+}

--- a/src/com/android/launcher3/LauncherPreferencesActivity.java
+++ b/src/com/android/launcher3/LauncherPreferencesActivity.java
@@ -1,0 +1,18 @@
+package com.android.launcher3;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import com.android.launcher3.LauncherPreferences.PrefsFragment;
+
+public class LauncherPreferencesActivity extends Activity {
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+	    super.onCreate(savedInstanceState);
+
+	    // Display the fragment as the main content.
+	    getFragmentManager().beginTransaction()
+	            .replace(android.R.id.content, new PrefsFragment())
+	            .commit();
+	}
+}

--- a/src/com/android/launcher3/NumberPreference.java
+++ b/src/com/android/launcher3/NumberPreference.java
@@ -1,0 +1,80 @@
+package com.android.launcher3;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.preference.DialogPreference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.widget.NumberPicker;
+
+public class NumberPreference extends DialogPreference {
+
+    private int mMin;
+    private int mMax;
+
+    private NumberPicker mNumberPicker;
+
+    public NumberPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.NumberPreference, 0, 0);
+        mMin = a.getInt(R.styleable.NumberPreference_min, 1);
+        mMax = a.getInt(R.styleable.NumberPreference_max, 3);
+        if(mMin<0 || mMin > mMax) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    protected View onCreateDialogView() {
+        mNumberPicker = new android.widget.NumberPicker(getContext());
+        return mNumberPicker;
+    }
+
+    @Override
+    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
+        super.onPrepareDialogBuilder(builder);
+        builder.setTitle(getTitle())
+            .setCancelable(true);
+    }
+
+    @Override
+    protected void onBindDialogView(View view) {
+        super.onBindDialogView(view);
+        NumberPicker p = (NumberPicker)view;
+        p.setMinValue(mMin);
+        p.setMaxValue(mMax);
+        p.setValue(getPersistedInt(mMin));
+    }
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        super.onDialogClosed(positiveResult);
+        if(positiveResult) {
+            persistInt(mNumberPicker.getValue());
+        }
+    }
+
+    @Override
+    protected void onSetInitialValue (boolean restorePersistedValue, Object defaultValue) {
+        int value = mMin;
+        if (restorePersistedValue) {
+            value = getPersistedInt(0);
+        } else {
+            Integer defVal = (Integer) defaultValue;
+            if (defVal != null) {
+                value = defVal;
+            }
+        }
+        if(value < mMin) {
+            value = mMin;
+        }
+    }
+
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int index) {
+        return a.getInteger(index, 0);
+    }
+
+}

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -51,6 +51,7 @@ import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Parcelable;
+import android.preference.PreferenceManager;
 import android.support.v4.view.ViewCompat;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -347,7 +348,12 @@ public class Workspace extends SmoothPagedView
             res.getInteger(R.integer.config_workspaceSpringLoadShrinkPercentage) / 100.0f;
         mOverviewModeShrinkFactor = grid.getOverviewModeScale();
         mCameraDistance = res.getInteger(R.integer.config_cameraDistance);
-        mOriginalDefaultPage = mDefaultPage = a.getInt(R.styleable.Workspace_defaultScreen, 1);
+
+        mOriginalDefaultPage = mDefaultPage =
+                PreferenceManager.getDefaultSharedPreferences(context)
+                        .getInt(LauncherPreferences.KEY_WORKSPACE_DEFAULT_PAGE,
+                                a.getInt(R.styleable.Workspace_defaultScreen, 0));
+
         a.recycle();
 
         setOnHierarchyChangeListener(this);


### PR DESCRIPTION
This patch allows a user to customize:
- Grid with and height
- Default homescreen position
- Visibility of the search bar

These items can be configured in a new Activity, which replaces the system
settings as target of the icon in overview mode

Shortcomings:
- Bounds for cols, rows and defaultWorkspace may need to be adjusted
- When one of the values changes, the Launcher activity gets recreated
  completely.
- When searchbar is hidden, you also lose the visible hints for the
  remove/appInfo drop targets.

Adapted for Lollipop by xplodwild

Change-Id: I5006d01f8a85e4daf3c3bb9a3dfb57c70e968878

Materialize Launcher settings

Before - http://i.imgur.com/BzZEbrr.png
After - http://i.imgur.com/qOVRJLv.png

Change-Id: I691f8da55b7c28c27820c48dca05834100a40871

Launcher3: Fix for 5.1

Change-Id: I2dcb9a79085cd220c8374a8f1d401309c2ea4e28